### PR TITLE
^ Update rust to 1.84.1

### DIFF
--- a/wasm-contract-optimizer.Dockerfile
+++ b/wasm-contract-optimizer.Dockerfile
@@ -1,5 +1,5 @@
 # Use the specified Rust image
-FROM rust:1.80.0-alpine3.20
+FROM rust:1.84.1-alpine3.20
 
 # Add the WebAssembly target
 RUN rustup target add wasm32-unknown-unknown


### PR DESCRIPTION
I can't compile my new contract project:
```
error: rustc 1.80.0 is not supported by the following packages:
  garde@0.22.0 requires rustc 1.81
  garde_derive@0.22.0 requires rustc 1.81
```